### PR TITLE
Upgrade to use Environment Files (#185)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Upload files
         run: npx @google/clasp push --force


### PR DESCRIPTION
in release workflow in view of the coming `set-output` deprecation

resolve #185 